### PR TITLE
feat: Add idb.onclose handler for IndexedDB unexpectedly close issue

### DIFF
--- a/.changeset/brown-cougars-reply.md
+++ b/.changeset/brown-cougars-reply.md
@@ -1,0 +1,5 @@
+---
+'@use-broadcast-channel/hooks': patch
+---
+
+Remove unmountAutoClose options

--- a/.changeset/fifty-sheep-hope.md
+++ b/.changeset/fifty-sheep-hope.md
@@ -1,0 +1,5 @@
+---
+'@use-broadcast-channel/hooks': patch
+---
+
+Add onclose handler for IndexedDB unexpectedly close [issue](https://github.com/pubkey/broadcast-channel#handling-indexeddb-onclose-events)

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -4,8 +4,6 @@ import { BroadcastChannel, BroadcastChannelOptions } from 'broadcast-channel';
 export interface UseBroadcastChannelOptions<T> {
   channelName: string;
   broadcastChannelOptions?: BroadcastChannelOptions;
-  /** @default true */
-  unmountAutoClose?: boolean;
   onMessage: (message: T) => void;
 }
 
@@ -19,7 +17,7 @@ export function useBroadcastChannel<T>(options: UseBroadcastChannelOptions<T>) {
   }, []);
 
   useEffect(() => {
-    const { channelName, broadcastChannelOptions, unmountAutoClose = true, onMessage } = options;
+    const { channelName, broadcastChannelOptions, onMessage } = options;
 
     let mounted = true;
     const channel = new BroadcastChannel<T>(channelName, broadcastChannelOptions);
@@ -35,9 +33,7 @@ export function useBroadcastChannel<T>(options: UseBroadcastChannelOptions<T>) {
     return () => {
       mounted = false;
       broadcastChannelRef.current = null;
-      if (unmountAutoClose) {
-        channel.close();
-      }
+      channel.close();
     };
   }, [options]);
 

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -30,10 +30,9 @@ export function useBroadcastChannel<T>(options: UseBroadcastChannelOptions<T>) {
       onMessage(message);
     };
 
-    channel.addEventListener('message', handler);
+    channel.onmessage = handler;
 
     return () => {
-      channel.removeEventListener('message', handler);
       mounted = false;
       broadcastChannelRef.current = null;
       if (unmountAutoClose) {


### PR DESCRIPTION
Issue: https://github.com/pubkey/broadcast-channel#handling-indexeddb-onclose-events

- Add idb.onclose handler for IndexedDB unexpectedly close issue
- Remove unmountAutoClose options